### PR TITLE
Fixing 3.6.4's `notscored` tag.

### DIFF
--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -447,7 +447,7 @@
   when: ubuntu1604cis_firewall == "iptables" and ubuntu1604cis_setup_firewall
   tags:
       - level1
-      - scored
+      - notscored
       - patch
       - rule_3.6.4
       - notimplemented


### PR DESCRIPTION
3.6.4 was tagged as `scored` even though it was `notscored`.