### PR TITLE
Fixes defaults for hosts.allowed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -336,10 +336,10 @@ ubuntu1604cis_time_synchronization_servers:
 
 # 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ubuntu1604cis_host_allow:
-  -"10.0.0.0/255.0.0.0"
-  -"172.16.0.0/255.240.0.0"
-  -"192.168.0.0/255.255.0.0"
-  -"0.0.0.0/0.0.0.0"
+  - "10.0.0.0/255.0.0.0"
+  - "172.16.0.0/255.240.0.0"
+  - "192.168.0.0/255.255.0.0"
+  - "0.0.0.0/0.0.0.0"
 
 ubuntu1604cis_firewall: firewalld
 # ubuntu1604cis_firewall: iptables


### PR DESCRIPTION
By default if you run this playbook as is, and then restart, it will break. This is because all items in the list will be expanded into a separate item. This renders into something like:

```
-, ", 1, 0, ., 0, ., 0, ., 0, /, 2, 5, 5, ., 0, ., 0, ., 0, ", 
```
Which will make it impossible to get back into your system unless you go through single-user mode to fix it
