### PR TITLE
Fixing tags which includes both level1 and level2

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -417,7 +417,6 @@
   tags:
       - scored
       - level1
-      - level2
       - patch
       - rule_1.1.13
 
@@ -487,7 +486,6 @@
       # - sticky_bit_on_worldwritable_dirs_audit.rc == '0'
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_1.1.20
@@ -618,7 +616,6 @@
       - ubuntu1604cis_rule_1_4_3
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_1.4.3
@@ -664,7 +661,6 @@
       - ubuntu1604cis_rule_1_5_2
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_1.5.2
@@ -908,7 +904,6 @@
       - ubuntu1604cis_rule_1_7_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - banner
@@ -919,7 +914,6 @@
       upgrade: dist
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_1.8

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -447,7 +447,7 @@
   when: ubuntu1604cis_firewall == "iptables" and ubuntu1604cis_setup_firewall
   tags:
       - level1
-      - scored
+      - notscored
       - patch
       - rule_3.6.4
       - notimplemented

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -484,7 +484,6 @@
   changed_when: false
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_3.7

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -404,7 +404,6 @@
       - ubuntu1604cis_rule_4_2_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -417,7 +416,6 @@
       - ubuntu1604cis_rule_4_2_1_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -431,7 +429,6 @@
       - ubuntu1604cis_rule_4_2_1_2
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -447,7 +444,6 @@
       - ubuntu1604cis_rule_4_2_1_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -460,7 +456,6 @@
       - ubuntu1604cis_rule_4_2_1_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -474,7 +469,6 @@
       - ubuntu1604cis_rule_4_2_1_5
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -488,7 +482,6 @@
       - ubuntu1604cis_rule_4_2_1_5
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -502,7 +495,6 @@
       - ubuntu1604cis_rule_4_2_2_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -516,7 +508,6 @@
       - ubuntu1604cis_rule_4_2_2_2
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -530,7 +521,6 @@
       - ubuntu1604cis_rule_4_2_2_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -544,7 +534,6 @@
       - ubuntu1604cis_rule_4_2_2_4
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -558,7 +547,6 @@
       - ubuntu1604cis_rule_4_2_2_5
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog
@@ -573,7 +561,6 @@
       - ubuntu1604cis_rule_4_2_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - syslog
@@ -604,7 +591,6 @@
       - ubuntu1604cis_rule_4_3
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - syslog

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -7,7 +7,6 @@
       - ubuntu1604cis_rule_5_1_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -23,7 +22,6 @@
       - ubuntu1604cis_rule_5_1_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -40,7 +38,6 @@
       - ubuntu1604cis_rule_5_1_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -57,7 +54,6 @@
       - ubuntu1604cis_rule_5_1_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -74,7 +70,6 @@
       - ubuntu1604cis_rule_5_1_5
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -91,7 +86,6 @@
       - ubuntu1604cis_rule_5_1_6
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -108,7 +102,6 @@
       - ubuntu1604cis_rule_5_1_7
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -155,7 +148,6 @@
       - ubuntu1604cis_rule_5_1_8
   tags:
       - level1
-      - level2
       - scored
       - patch
       - cron
@@ -172,7 +164,6 @@
       - ubuntu1604cis_rule_5_2_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -188,7 +179,6 @@
       - ubuntu1604cis_rule_5_2_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -204,7 +194,6 @@
       - ubuntu1604cis_rule_5_2_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -220,7 +209,6 @@
       - ubuntu1604cis_rule_5_2_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -236,7 +224,6 @@
       - ubuntu1604cis_rule_5_2_5
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -252,7 +239,6 @@
       - ubuntu1604cis_rule_5_2_6
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -268,7 +254,6 @@
       - ubuntu1604cis_rule_5_2_7
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -284,7 +269,6 @@
       - ubuntu1604cis_rule_5_2_8
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -300,7 +284,6 @@
       - ubuntu1604cis_rule_5_2_9
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -316,7 +299,6 @@
       - ubuntu1604cis_rule_5_2_10
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -332,7 +314,6 @@
       - ubuntu1604cis_rule_5_2_11
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -357,7 +338,6 @@
       - ubuntu1604cis_rule_5_2_12
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -373,7 +353,6 @@
       - ubuntu1604cis_rule_5_2_13
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -428,7 +407,6 @@
       - ubuntu1604cis_rule_5_2_14
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -444,7 +422,6 @@
       - ubuntu1604cis_rule_5_2_15
   tags:
       - level1
-      - level2
       - scored
       - patch
       - sshd
@@ -474,7 +451,6 @@
       - ubuntu1604cis_rule_5_3_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.3.1
@@ -486,7 +462,6 @@
       - ubuntu1604cis_rule_5_3_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.3.2
@@ -499,7 +474,6 @@
       - ubuntu1604cis_rule_5_3_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.3.3
@@ -513,7 +487,6 @@
       - ubuntu1604cis_rule_5_3_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.3.4
@@ -528,7 +501,6 @@
       - ubuntu1604cis_rule_5_4_1_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.4.1.1
@@ -543,7 +515,6 @@
       - ubuntu1604cis_rule_5_4_1_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.4.1.2
@@ -558,7 +529,6 @@
       - ubuntu1604cis_rule_5_4_1_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_5.4.1.3
@@ -570,7 +540,6 @@
       - ubuntu1604cis_rule_5_4_1_4
   tags:
       - level1
-      - level2
       - patch
       - rule_5.4.1.4
       - notimplemented
@@ -582,7 +551,6 @@
       - ubuntu1604cis_rule_5_4_2
   tags:
       - level1
-      - level2
       - patch
       - rule_5.4.2
       - notimplemented
@@ -595,7 +563,6 @@
       - ubuntu1604cis_rule_5_4_3
   tags:
       - level1
-      - level2
       - patch
       - rule_5.4.3
 
@@ -623,7 +590,6 @@
       - ubuntu1604cis_rule_5_4_4
   tags:
       - level1
-      - level2
       - patch
       - rule_5.4.4
 
@@ -634,7 +600,6 @@
       - ubuntu1604cis_rule_5_5
   tags:
       - level1
-      - level2
       - patch
       - rule_5.5
       - notscored
@@ -650,7 +615,6 @@
       - ubuntu1604cis_rule_5_6
   tags:
       - level1
-      - level2
       - patch
       - rule_5.6
 
@@ -662,6 +626,5 @@
       - ubuntu1604cis_rule_5_6
   tags:
       - level1
-      - level2
       - patch
       - rule_5.6

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -21,7 +21,6 @@
       - ubuntu1604cis_rule_6_1_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.2
@@ -36,7 +35,6 @@
       - ubuntu1604cis_rule_6_1_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.3
@@ -51,7 +49,6 @@
       - ubuntu1604cis_rule_6_1_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.4
@@ -66,7 +63,6 @@
       - ubuntu1604cis_rule_6_1_5
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.5
@@ -81,7 +77,6 @@
       - ubuntu1604cis_rule_6_1_6
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.6
@@ -96,7 +91,6 @@
       - ubuntu1604cis_rule_6_1_7
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.7
@@ -111,7 +105,6 @@
       - ubuntu1604cis_rule_6_1_8
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.8
@@ -126,7 +119,6 @@
       - ubuntu1604cis_rule_6_1_9
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.9
@@ -138,7 +130,6 @@
       - ubuntu1604cis_rule_6_1_10
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.10
@@ -151,7 +142,6 @@
       - ubuntu1604cis_rule_6_1_11
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.11
@@ -164,7 +154,6 @@
       - ubuntu1604cis_rule_6_1_12
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.1.12
@@ -177,7 +166,6 @@
       - ubuntu1604cis_rule_6_1_13
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_6.1.13
@@ -190,7 +178,6 @@
       - ubuntu1604cis_rule_6_1_14
   tags:
       - level1
-      - level2
       - notscored
       - patch
       - rule_6.1.14
@@ -206,7 +193,6 @@
       - ubuntu1604cis_rule_6_2_1
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.1
@@ -219,7 +205,6 @@
       - ubuntu1604cis_rule_6_2_2
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.2
@@ -232,7 +217,6 @@
       - ubuntu1604cis_rule_6_2_3
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.3
@@ -245,7 +229,6 @@
       - ubuntu1604cis_rule_6_2_4
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.4
@@ -260,7 +243,6 @@
       - ubuntu1604cis_rule_6_2_5
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.5
@@ -272,7 +254,6 @@
       - ubuntu1604cis_rule_6_2_6
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.6
@@ -298,7 +279,6 @@
       - ubuntu1604cis_rule_6_2_6
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.6
@@ -313,7 +293,6 @@
       - fixsudo.stdout_lines[0] != ""
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.6
@@ -325,7 +304,6 @@
       - ubuntu1604cis_rule_6_2_7
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.7
@@ -338,7 +316,6 @@
       - ubuntu1604cis_rule_6_2_8
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.8
@@ -351,7 +328,6 @@
       - ubuntu1604cis_rule_6_2_9
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.9
@@ -364,7 +340,6 @@
       - ubuntu1604cis_rule_6_2_10
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.10
@@ -379,7 +354,6 @@
       - ubuntu1604cis_rule_6_2_11
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.11
@@ -393,7 +367,6 @@
       - ubuntu1604cis_rule_6_2_12
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.12
@@ -407,7 +380,6 @@
       - ubuntu1604cis_rule_6_2_14
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.14
@@ -419,7 +391,6 @@
       - ubuntu1604cis_rule_6_2_15
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.15
@@ -432,7 +403,6 @@
       - ubuntu1604cis_rule_6_2_16
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.16
@@ -445,7 +415,6 @@
       - ubuntu1604cis_rule_6_2_17
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.17
@@ -458,7 +427,6 @@
       - ubuntu1604cis_rule_6_2_18
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.18
@@ -471,7 +439,6 @@
       - ubuntu1604cis_rule_6_2_19
   tags:
       - level1
-      - level2
       - scored
       - patch
       - rule_6.2.19


### PR DESCRIPTION
It is a fix commit request for the tasks with `level1` and `level2`. Those are `level1` but also include `level2`, unlike some other tasks which only have `level1 `tag.