### PR TITLE
fixed 1.4.1 missing condition to skip

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -586,7 +586,9 @@
       owner: root
       group: root
       mode: 0600
-  when: ansible_os_family == "Debian"
+  when: 
+      - ansible_os_family == "Debian"
+      - ubuntu1604cis_rule_1_4_1
   tags:
       - level1
       - scored


### PR DESCRIPTION
This condition wasn't valid because I used a docker image that does not have grub.