### PR TITLE
correct syntax for the defaults for time sync servers and firewall services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -329,10 +329,10 @@ ubuntu1604cis_time_synchronization: chrony
 # ubuntu1604cis_time_synchronization: ntp
 
 ubuntu1604cis_time_synchronization_servers:
-  -0.pool.ntp.org
-  -1.pool.ntp.org
-  -2.pool.ntp.org
-  -3.pool.ntp.org
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
 
 # 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ubuntu1604cis_host_allow:
@@ -345,8 +345,8 @@ ubuntu1604cis_firewall: firewalld
 # ubuntu1604cis_firewall: iptables
 
 ubuntu1604cis_firewall_services:
-  -ssh
-  -dhcpv6-client
+  - ssh
+  - dhcpv6-client
 
 # Warning Banner Content (issue, issue.net, motd)
 ubuntu1604cis_warning_banner: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -384,7 +384,7 @@ ubuntu1604cis_syslog: rsyslog
 
 ubuntu1604cis_vartmp:
   source: /tmp
-  fstype: falsene
+  fstype: false
   opts: "defaults, nodev, nosuid, noexec, bind"
   enabled: false
 


### PR DESCRIPTION
Similar to [this hosts.allowed issue](https://github.com/florianutz/Ubuntu1604-CIS/pull/18). The default time sync config was broken by a syntax error. This was causing a chrony / ntp config that looks like:
```
server - minpoll 8
server 0 minpoll 8
server . minpoll 8
server p minpoll 8
server o minpoll 8
server o minpoll 8
server l minpoll 8
server . minpoll 8
server n minpoll 8
server t minpoll 8
server p minpoll 8
server . minpoll 8
server o minpoll 8
server r minpoll 8
server g minpoll 8
```