### PR TITLE
Don't loop over apt

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -26,6 +26,7 @@
       masked: false
       state: reloaded
   when: ansible_virtualization_type != "docker"
+  ignore_errors: "{{ ubuntu1604cis_ignore_remount_errors }}"
 
 - name: systemd restart var-tmp.mount
   become: true
@@ -35,6 +36,7 @@
       enabled: true
       masked: false
       state: reloaded
+  ignore_errors: "{{ ubuntu1604cis_ignore_remount_errors }}"
 
 - name: generate new grub config
   become: true

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,10 +7,9 @@
   pre_tasks:
     - name: install packages for testing under docker
       apt:
-        name: "{{ item }}"
-        state: present
-      with_items:
+        name:
         - openssh-server
+        state: present
     - name: pretask2
       file:
         name: /boot/grub

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -8,7 +8,7 @@
     - name: install packages for testing under docker
       apt:
         name:
-        - openssh-server
+          - openssh-server
         state: present
     - name: pretask2
       file:

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -8,11 +8,10 @@
 
 - name: "POST | Perform apt package cleanup"
   apt:
-    name: "{{ item }}"
+    name: "{{ apt_rc_packages.stdout_lines }}"
     state: absent
     purge: true
   changed_when: false
   ignore_errors: true
-  with_items: "{{ apt_rc_packages.stdout_lines }}"
   tags:
     - skip_ansible_lint

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -303,11 +303,10 @@
 
 - name: "SCORED | 2.2.2 | PATCH | Ensure X Window System is not installed"
   apt:
-      name: "{{item}}"
+      name:
+          - "@X Window System"
+          - "x11*"
       state: absent
-  with_items:
-      - "@X Window System"
-      - "x11*"
   when:
       - ubuntu1604cis_xwindows_required == false
       - ubuntu1604cis_rule_2_2_2


### PR DESCRIPTION
Ansible is deprecating the special handling of loops on apt tasks in favor of lists of names. This PR updates this role to reflect that change.