### PR TITLE
add option to ignore remount errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ ubuntu1604cis_section6: true
 
 ubuntu1604cis_selinux_disable: false
 
+# Ignore remount errors if you're building an image or are going to reboot anyway
+ubuntu1604_cis_ignore_remount_errors: false
+
 # These variables correspond with the CIS rule IDs or paragraph numbers defined in
 # the CIS benchmark documents.
 # PLEASE NOTE: These work in coordination with the section # group variables and tags.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ ubuntu1604cis_section6: true
 ubuntu1604cis_selinux_disable: false
 
 # Ignore remount errors if you're building an image or are going to reboot anyway
-ubuntu1604_cis_ignore_remount_errors: false
+ubuntu1604cis_ignore_remount_errors: false
 
 # These variables correspond with the CIS rule IDs or paragraph numbers defined in
 # the CIS benchmark documents.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -26,6 +26,7 @@
       masked: false
       state: reloaded
   when: ansible_virtualization_type != "docker"
+  ignore_errors: ubuntu1604cis_ignore_remount_errors
 
 - name: systemd restart var-tmp.mount
   become: true
@@ -35,6 +36,7 @@
       enabled: true
       masked: false
       state: reloaded
+  ignore_errors: ubuntu1604cis_ignore_remount_errors
 
 - name: generate new grub config
   become: true


### PR DESCRIPTION
If anything is using the tmp or var-tmp directories restarting those services will fail. This PR creates a variable to ignore errors when restarting those services, which is safe if you're building an image or if you're going to be rebooting the server.