### PR TITLE
Update readme to provide instructions for how to download ubuntu 16 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With this in the file requirements.yml:
 - src: https://github.com/florianutz/Ubuntu1604-CIS.git
 ```
 
-Based on [CIS Ubuntu Benchmark v1.1.0 - 12-28-2017 ](https://community.cisecurity.org/collab/public/index.php).
+Based on [CIS Ubuntu Benchmark v1.1.0 - 12-28-2017 ](https://www.cisecurity.org/benchmark/ubuntu_linux/). To download this guide, you will need to click the `Download Latest CIS Benchmark Guide (For Ubuntu Linus 18.04)` and register. An email with a personal download link will be sent to your registered email address. From that link you can download the Ubuntu 16.04 guide.
 
 This repo originated from work done by [MindPointGroup](https://github.com/MindPointGroup/RHEL7-CIS)
 
@@ -45,7 +45,7 @@ There are many role variables defined in defaults/main.yml. This list shows the 
 
 **ubuntu1604cis_section5**: CIS - Access, Authentication and Authorization settings (Section 5) (Default: true)
 
-**ubuntu1604cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)  
+**ubuntu1604cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)
 
 ##### Disable all selinux functions
 `ubuntu1604cis_selinux_disable: false`
@@ -54,44 +54,44 @@ There are many role variables defined in defaults/main.yml. This list shows the 
 ###### These control whether a server should or should not be allowed to continue to run these services
 
 ```
-ubuntu1604cis_avahi_server: false  
-ubuntu1604cis_cups_server: false  
-ubuntu1604cis_dhcp_server: false  
-ubuntu1604cis_ldap_server: false  
-ubuntu1604cis_telnet_server: false  
-ubuntu1604cis_nfs_server: false  
-ubuntu1604cis_rpc_server: false  
-ubuntu1604cis_ntalk_server: false  
-ubuntu1604cis_rsyncd_server: false  
-ubuntu1604cis_tftp_server: false  
-ubuntu1604cis_rsh_server: false  
-ubuntu1604cis_nis_server: false  
-ubuntu1604cis_snmp_server: false  
-ubuntu1604cis_squid_server: false  
-ubuntu1604cis_smb_server: false  
-ubuntu1604cis_dovecot_server: false  
-ubuntu1604cis_httpd_server: false  
-ubuntu1604cis_vsftpd_server: false  
-ubuntu1604cis_named_server: false  
-ubuntu1604cis_bind: false  
-ubuntu1604cis_vsftpd: false  
-ubuntu1604cis_httpd: false  
-ubuntu1604cis_dovecot: false  
-ubuntu1604cis_samba: false  
-ubuntu1604cis_squid: false  
-ubuntu1604cis_net_snmp: false  
-```  
+ubuntu1604cis_avahi_server: false
+ubuntu1604cis_cups_server: false
+ubuntu1604cis_dhcp_server: false
+ubuntu1604cis_ldap_server: false
+ubuntu1604cis_telnet_server: false
+ubuntu1604cis_nfs_server: false
+ubuntu1604cis_rpc_server: false
+ubuntu1604cis_ntalk_server: false
+ubuntu1604cis_rsyncd_server: false
+ubuntu1604cis_tftp_server: false
+ubuntu1604cis_rsh_server: false
+ubuntu1604cis_nis_server: false
+ubuntu1604cis_snmp_server: false
+ubuntu1604cis_squid_server: false
+ubuntu1604cis_smb_server: false
+ubuntu1604cis_dovecot_server: false
+ubuntu1604cis_httpd_server: false
+ubuntu1604cis_vsftpd_server: false
+ubuntu1604cis_named_server: false
+ubuntu1604cis_bind: false
+ubuntu1604cis_vsftpd: false
+ubuntu1604cis_httpd: false
+ubuntu1604cis_dovecot: false
+ubuntu1604cis_samba: false
+ubuntu1604cis_squid: false
+ubuntu1604cis_net_snmp: false
+```
 
 ##### Designate server as a Mail server
 `ubuntu1604cis_is_mail_server: false`
 
 
 ##### System network parameters (host only OR host and router)
-`ubuntu1604cis_is_router: false`  
+`ubuntu1604cis_is_router: false`
 
 
 ##### IPv6 required
-`ubuntu1604cis_ipv6_required: true`  
+`ubuntu1604cis_ipv6_required: true`
 
 
 ##### AIDE
@@ -107,7 +107,7 @@ ubuntu1604cis_aide_cron:
   aide_hour: 5
   aide_day: '*'
   aide_month: '*'
-  aide_weekday: '*'  
+  aide_weekday: '*'
 ```
 
 ##### SELinux policy
@@ -122,7 +122,7 @@ ubuntu1604cis_aide_cron:
 ```
 ubuntu1604cis_openldap_clients_required: false
 ubuntu1604cis_telnet_required: false
-ubuntu1604cis_talk_required: false  
+ubuntu1604cis_talk_required: false
 ubuntu1604cis_rsh_required: false
 ubuntu1604cis_ypbind_required: false
 ```
@@ -136,16 +136,16 @@ ubuntu1604cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
-    - 3.pool.ntp.org  
-```  
+    - 3.pool.ntp.org
+```
 
 ##### 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ```
 ubuntu1604cis_host_allow:
-  - "10.0.0.0/255.0.0.0"  
-  - "172.16.0.0/255.240.0.0"  
-  - "192.168.0.0/255.255.0.0"    
-```  
+  - "10.0.0.0/255.0.0.0"
+  - "172.16.0.0/255.240.0.0"
+  - "192.168.0.0/255.255.0.0"
+```
 
 ```
 ubuntu1604cis_firewall: firewalld


### PR DESCRIPTION
The link to the readme no longer works. I updated it along with instructions on how to navigate the current version of the CIS site - this is necessary because their wording implies they only have a Ubuntu 18 and an Ubuntu 14 guide, and the downloads are hidden behind a registration wall. 