### PR TITLE
Updates to address issues in section 2 + minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are many role variables defined in defaults/main.yml. This list shows the 
 
 **ubuntu1604cis_section5**: CIS - Access, Authentication and Authorization settings (Section 5) (Default: true)
 
-**ubuntu1604cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)  
+**ubuntu1604cis_section6**: CIS - System Maintenance settings (Section 6) (Default: true)
 
 ##### Disable all selinux functions
 `ubuntu1604cis_selinux_disable: false`
@@ -54,44 +54,37 @@ There are many role variables defined in defaults/main.yml. This list shows the 
 ###### These control whether a server should or should not be allowed to continue to run these services
 
 ```
-ubuntu1604cis_avahi_server: false  
-ubuntu1604cis_cups_server: false  
-ubuntu1604cis_dhcp_server: false  
-ubuntu1604cis_ldap_server: false  
-ubuntu1604cis_telnet_server: false  
-ubuntu1604cis_nfs_server: false  
-ubuntu1604cis_rpc_server: false  
-ubuntu1604cis_ntalk_server: false  
-ubuntu1604cis_rsyncd_server: false  
-ubuntu1604cis_tftp_server: false  
-ubuntu1604cis_rsh_server: false  
-ubuntu1604cis_nis_server: false  
-ubuntu1604cis_snmp_server: false  
-ubuntu1604cis_squid_server: false  
-ubuntu1604cis_smb_server: false  
-ubuntu1604cis_dovecot_server: false  
-ubuntu1604cis_httpd_server: false  
-ubuntu1604cis_vsftpd_server: false  
-ubuntu1604cis_named_server: false  
-ubuntu1604cis_bind: false  
-ubuntu1604cis_vsftpd: false  
-ubuntu1604cis_httpd: false  
-ubuntu1604cis_dovecot: false  
-ubuntu1604cis_samba: false  
-ubuntu1604cis_squid: false  
-ubuntu1604cis_net_snmp: false  
-```  
+ubuntu1604cis_avahi_server: false
+ubuntu1604cis_cups_server: false
+ubuntu1604cis_dhcp_server: false
+ubuntu1604cis_ldap_server: false
+ubuntu1604cis_telnet_server: false
+ubuntu1604cis_nfs_server: false
+ubuntu1604cis_rpc_server: false
+ubuntu1604cis_ntalk_server: false
+ubuntu1604cis_rsyncd_server: false
+ubuntu1604cis_tftp_server: false
+ubuntu1604cis_rsync_server: false
+ubuntu1604cis_nis_server: false
+ubuntu1604cis_snmp_server: false
+ubuntu1604cis_squid_server: false
+ubuntu1604cis_smb_server: false
+ubuntu1604cis_dovecot_server: false
+ubuntu1604cis_apache2_server: false
+ubuntu1604cis_vsftpd_server: false
+ubuntu1604cis_named_server: false
+```
 
 ##### Designate server as a Mail server
 `ubuntu1604cis_is_mail_server: false`
 
 
 ##### System network parameters (host only OR host and router)
-`ubuntu1604cis_is_router: false`  
+`ubuntu1604cis_is_router: false`
 
 
 ##### IPv6 required
-`ubuntu1604cis_ipv6_required: true`  
+`ubuntu1604cis_ipv6_required: true`
 
 
 ##### AIDE
@@ -107,7 +100,7 @@ ubuntu1604cis_aide_cron:
   aide_hour: 5
   aide_day: '*'
   aide_month: '*'
-  aide_weekday: '*'  
+  aide_weekday: '*'
 ```
 
 ##### SELinux policy
@@ -120,11 +113,11 @@ ubuntu1604cis_aide_cron:
 
 ##### Client application requirements
 ```
-ubuntu1604cis_openldap_clients_required: false
+ubuntu1604cis_ldap_utils_required: false
 ubuntu1604cis_telnet_required: false
-ubuntu1604cis_talk_required: false  
+ubuntu1604cis_talk_required: false
 ubuntu1604cis_rsh_required: false
-ubuntu1604cis_ypbind_required: false
+ubuntu1604cis_nis_required: false
 ```
 
 ##### Time Synchronization
@@ -136,16 +129,16 @@ ubuntu1604cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
-    - 3.pool.ntp.org  
-```  
+    - 3.pool.ntp.org
+```
 
 ##### 3.4.2 | PATCH | Ensure /etc/hosts.allow is configured
 ```
 ubuntu1604cis_host_allow:
-  - "10.0.0.0/255.0.0.0"  
-  - "172.16.0.0/255.240.0.0"  
-  - "192.168.0.0/255.255.0.0"    
-```  
+  - "10.0.0.0/255.0.0.0"
+  - "172.16.0.0/255.240.0.0"
+  - "192.168.0.0/255.255.0.0"
+```
 
 ```
 ubuntu1604cis_firewall: firewalld

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,10 @@ ubuntu1604cis_rule_2_1_4: true
 ubuntu1604cis_rule_2_1_5: true
 ubuntu1604cis_rule_2_1_6: true
 ubuntu1604cis_rule_2_1_7: true
+ubuntu1604cis_rule_2_1_8: true
+ubuntu1604cis_rule_2_1_9: true
+ubuntu1604cis_rule_2_1_10: true
+ubuntu1604cis_rule_2_1_11: true
 ubuntu1604cis_rule_2_2_1_1: true
 ubuntu1604cis_rule_2_2_1_2: true
 ubuntu1604cis_rule_2_2_1_3: true
@@ -257,37 +261,22 @@ ubuntu1604cis_avahi_server: false
 ubuntu1604cis_cups_server: false
 ubuntu1604cis_dhcp_server: false
 ubuntu1604cis_ldap_server: false
-ubuntu1604cis_telnet_server: false
 ubuntu1604cis_nfs_server: false
 ubuntu1604cis_rpc_server: false
-ubuntu1604cis_ntalk_server: false
-ubuntu1604cis_rsyncd_server: false
-ubuntu1604cis_tftp_server: false
-ubuntu1604cis_rsh_server: false
 ubuntu1604cis_nis_server: false
+ubuntu1604cis_rsync_server: false
 ubuntu1604cis_snmp_server: false
 ubuntu1604cis_squid_server: false
 ubuntu1604cis_smb_server: false
 ubuntu1604cis_dovecot_server: false
-ubuntu1604cis_httpd_server: false
+ubuntu1604cis_apache2_server: false
 ubuntu1604cis_vsftpd_server: false
-ubuntu1604cis_named_server: false
+ubuntu1604cis_bind9_server: false
 ubuntu1604cis_nfs_rpc_server: false
 ubuntu1604cis_is_mail_server: false
-ubuntu1604cis_bind: false
-ubuntu1604cis_vsftpd: false
-ubuntu1604cis_httpd: false
-ubuntu1604cis_dovecot: false
-ubuntu1604cis_samba: false
-ubuntu1604cis_squid: false
-ubuntu1604cis_net_snmp: false
-ubuntu1604cis_allow_autofs: false
 
 # xinetd required
 ubuntu1604cis_xinetd_required: false
-
-# RedHat Satellite Subscription items
-ubuntu1604cis_rhnsd_required: false
 
 # 1.4.2 Bootloader password
 ubuntu1604cis_bootloader_password: random
@@ -321,11 +310,11 @@ ubuntu1604cis_gui: false
 # Set to 'true' if X Windows is needed in your environment
 ubuntu1604cis_xwindows_required: false
 
-ubuntu1604cis_openldap_clients_required: false
+ubuntu1604cis_ldap_utils_required: false
 ubuntu1604cis_telnet_required: false
 ubuntu1604cis_talk_required: false
 ubuntu1604cis_rsh_required: false
-ubuntu1604cis_ypbind_required: false
+ubuntu1604cis_nis_required: false
 
 # Time Synchronization
 ubuntu1604cis_time_synchronization: chrony

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -106,12 +106,21 @@
   changed_when: false
   check_mode: false
 
-- name: "PRELIM | Check for dhcpd service"
+- name: "PRELIM | Check for isc-dhcp-server service"
   shell: "set -o pipefail
-      systemctl show dhcpd | grep LoadState | cut -d = -f 2"
+      systemctl show isc-dhcp-server | grep LoadState | cut -d = -f 2"
   args:
       executable: /bin/bash
-  register: dhcpd_service_status
+  register: isc-dhcp-server_service_status
+  changed_when: false
+  check_mode: false
+
+- name: "PRELIM | Check for isc-dhcp-server6 service"
+  shell: "set -o pipefail
+      systemctl show isc-dhcp-server6 | grep LoadState | cut -d = -f 2"
+  args:
+      executable: /bin/bash
+  register: isc-dhcp-server6_service_status
   changed_when: false
   check_mode: false
 
@@ -142,12 +151,12 @@
   changed_when: false
   check_mode: false
 
-- name: "PRELIM | Check for named service"
+- name: "PRELIM | Check for bind9 service"
   shell: "set -o pipefail
-      systemctl show named | grep LoadState | cut -d = -f 2"
+      systemctl show bind9 | grep LoadState | cut -d = -f 2"
   args:
       executable: /bin/bash
-  register: named_service_status
+  register: bind9_service_status
   changed_when: false
   check_mode: false
 
@@ -183,7 +192,7 @@
       systemctl show smb | grep LoadState | cut -d = -f 2"
   args:
       executable: /bin/bash
-  register: smb_service_status
+  register: smbd_service_status
   changed_when: false
   check_mode: false
 

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -1,31 +1,7 @@
 ---
-- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram,chargen-stream"
-  block:
-      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
-        stat:
-            path: /etc/xinetd.d/chargen-dgram
-        register: chargen_dgram_service
-
-      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-dgram"
-        service:
-            name: chargen-dgram
-            enabled: no
-        notify: restart xinetd
-        when:
-            - chargen_dgram_service.stat.exists
-
-      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
-        stat:
-            path: /etc/xinetd.d/chargen-stream
-        register: chargen_stream_service
-
-      - name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled | chargen-stream"
-        service:
-            name: chargen-stream
-            enabled: no
-        notify: restart xinetd
-        when:
-            - chargen_stream_service.stat.exists
+- name: "SCORED | 2.1.1 | PATCH | Ensure chargen services are not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_1
   tags:
@@ -35,34 +11,11 @@
       - patch
       - rule_2.1.1
       - skip_ansible_lint
+      - notimplemented
 
-- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram,daytime-stream"
-  block:
-      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
-        stat:
-            path: /etc/xinetd.d/daytime-dgram
-        register: daytime_dgram_service
-
-      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-dgram"
-        service:
-            name: daytime-dgram
-            enabled: no
-        notify: restart xinetd
-        when:
-            - daytime_dgram_service.stat.exists
-
-      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
-        stat:
-            path: /etc/xinetd.d/daytime-stream
-        register: daytime_stream_service
-
-      - name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled | daytime-stream"
-        service:
-            name: daytime-stream
-            enabled: no
-        notify: restart xinetd
-        when:
-            - daytime_stream_service.stat.exists
+- name: "SCORED | 2.1.2 | PATCH | Ensure daytime services are not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_2
   tags:
@@ -72,33 +25,9 @@
       - rule_2.1.2
       - skip_ansible_lint
 
-- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram,discard-stream"
-  block:
-      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
-        stat:
-            path: /etc/xinetd.d/discard-dgram
-        register: discard_dgram_service
-
-      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-dgram"
-        service:
-            name: discard-dgram
-            enabled: no
-        notify: restart xinetd
-        when:
-            - discard_dgram_service.stat.exists
-
-      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
-        stat:
-            path: /etc/xinetd.d/discard-stream
-        register: discard_stream_service
-
-      - name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled | discard-stream"
-        service:
-            name: discard-stream
-            enabled: no
-        notify: restart xinetd
-        when:
-            - discard_stream_service.stat.exists
+- name: "SCORED | 2.1.3 | PATCH | Ensure discard services are not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_3
   tags:
@@ -107,34 +36,11 @@
       - patch
       - rule_2.1.3
       - skip_ansible_lint
+      - notimplemented
 
-- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram,echo-stream"
-  block:
-      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
-        stat:
-            path: /etc/xinetd.d/echo-dgram
-        register: echo_dgram_service
-
-      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-dgram"
-        service:
-            name: echo-dgram
-            enabled: no
-        notify: restart xinetd
-        when:
-            - echo_dgram_service.stat.exists
-
-      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
-        stat:
-            path: /etc/xinetd.d/echo-stream
-        register: echo_stream_service
-
-      - name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled | echo-stream"
-        service:
-            name: echo-stream
-            enabled: no
-        notify: restart xinetd
-        when:
-            - echo_stream_service.stat.exists
+- name: "SCORED | 2.1.4 | PATCH | Ensure echo services are not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_4
   tags:
@@ -143,34 +49,11 @@
       - patch
       - rule_2.1.4
       - skip_ansible_lint
+      - notimplemented
 
-- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram,time-stream"
-  block:
-      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
-        stat:
-            path: /etc/xinetd.d/time-dgram
-        register: time_dgram_service
-
-      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-dgram"
-        service:
-            name: time-dgram
-            enabled: no
-        notify: restart xinetd
-        when:
-            - time_dgram_service.stat.exists
-
-      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
-        stat:
-            path: /etc/xinetd.d/time-stream
-        register: time_stream_service
-
-      - name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled | time-stream"
-        service:
-            name: time-stream
-            enabled: no
-        notify: restart xinetd
-        when:
-            - time_stream_service.stat.exists
+- name: "SCORED | 2.1.5 | PATCH | Ensure time services are not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_5
   tags:
@@ -179,24 +62,11 @@
       - patch
       - rule_2.1.5
       - skip_ansible_lint
+      - notimplemented
 
-- name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-  block:
-      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-        stat:
-            path: /etc/xinetd.d/tftp
-        register: tftp_service
-
-      - name: "SCORED | 2.1.6 | PATCH | Ensure tftp server is not enabled"
-        service:
-            name: tftp
-            enabled: no
-        notify: restart xinetd
-        when:
-            - tftp_service.stat.exists
-            - not ubuntu1604cis_tftp_server
-        tags:
-            - skip_ansible_lint
+- name: "SCORED | 2.1.6 | PATCH | Ensure rsh server is not enabled"
+  command: /bin/true
+  changed_when: false
   when:
       - ubuntu1604cis_rule_2_1_6
   tags:
@@ -204,21 +74,75 @@
       - scored
       - patch
       - rule_2.1.6
+      - not implemented
 
-- name: "SCORED | 2.1.7 | PATCH | Ensure xinetd is not enabled"
-  service:
-      name: xinetd
-      state: stopped
-      enabled: false
+- name: "SCORED | 2.1.7 | PATCH | Ensure talk is not enabled"
+  command: /bin/true
+  changed_when: false
   when:
-      - xinetd_service_status.stdout == "loaded"
-      - not ubuntu1604cis_xinetd_required
       - ubuntu1604cis_rule_2_1_7
   tags:
       - level1
       - patch
       - scored
       - rule_2.1.7
+      - notimplemented
+
+- name: "SCORED | 2.1.8 | PATCH | Ensure telnet is not enabled"
+  command: /bin/true
+  changed_when: false
+  when:
+      - ubuntu1604cis_rule_2_1_8
+  tags:
+      - level1
+      - patch
+      - scored
+      - rule_2.1.8
+      - notimplemented
+
+- name: "SCORED | 2.1.9 | PATCH | Ensure tftp is not enabled"
+  command: /bin/true
+  changed_when: false
+  when:
+      - ubuntu1604cis_rule_2_1_9
+  tags:
+      - level1
+      - patch
+      - scored
+      - rule_2.1.9
+      - notimplemented
+
+name: "SCORED | 2.1.10 | PATCH | Ensure xinetd is not enabled"
+  systemd:
+      name: xinetd
+      state: absent
+      enabled: false
+  when:
+      - xinetd_service_status.stdout == "loaded"
+      - not ubuntu1604cis_xinetd_required
+      - ubuntu1604cis_rule_2_1_10
+  tags:
+      - level1
+      - patch
+      - scored
+      - rule_2.1.10
+
+
+name: "SCORED | 2.1.11 | PATCH | Ensure openbsd-inetd is not enabled"
+  systemd:
+      name: openbsd-inetd
+      state: absent
+      enabled: false
+  when:
+      - xinetd_service_status.stdout == "loaded"
+      - not ubuntu1604cis_xinetd_required
+      - ubuntu1604cis_rule_2_1_11
+  tags:
+      - level1
+      - patch
+      - scored
+      - rule_2.1.11
+
 
 - name: "NOTSCORED | 2.2.1.1 | PATCH | Ensure time synchronization is in use"
   block:
@@ -229,13 +153,13 @@
             install_recommends: false
 
       - name: "NOTSCORED | 2.2.1.1 | PATCH | Ensure time synchronization is in use - service start"
-        service:
+        systemd:
             name: "{{ ubuntu1604cis_time_synchronization }}"
             state: started
             enabled: true
 
       - name: "NOTSCORED | 2.2.1.1 | PATCH | Ensure time synchronization is in use - service stop ntp"
-        service:
+        systemd:
             name: "{{ ntp_service[ansible_os_family] }}"
             state: stopped
             enabled: false
@@ -244,7 +168,7 @@
             - ntpd_service_status.stdout == "loaded"
 
       - name: "NOTSCORED | 2.2.1.1 | PATCH | Ensure time synchronization is in use - service stop chrony"
-        service:
+        systemd:
             name: chronyd
             state: stopped
             enabled: false
@@ -328,6 +252,7 @@
       name:
           - "@X Window System"
           - "x11*"
+          - "xserver-xorg*"
       state: absent
   when:
       - not ubuntu1604cis_xwindows_required
@@ -340,7 +265,7 @@
       - rule_2.2.2
 
 - name: "SCORED | 2.2.3 | PATCH | Ensure Avahi Server is not enabled"
-  service:
+  systemd:
       name: avahi-daemon
       state: stopped
       enabled: false
@@ -357,7 +282,7 @@
       - rule_2.2.3
 
 - name: "SCORED | 2.2.4 | PATCH | Ensure CUPS is not enabled"
-  service:
+  systemd:
       name: cups
       state: stopped
       enabled: false
@@ -374,13 +299,23 @@
       - rule_2.2.4
 
 - name: "SCORED | 2.2.5 | PATCH | Ensure DHCP Server is not enabled"
-  service:
-      name: dhcpd
-      state: stopped
-      enabled: false
+  block:
+    - name: "SCORED | 2.2.5 | PATCH | Ensure DHCP Server is not enabled | Stop isc-dhcp-server"
+      systemd:
+        name: isc-dhcp-server
+        state: stopped
+        enabled: false
+      when:
+         - isc-dhcp-server.stdout == "loaded"
+    - name: "SCORED | 2.2.5 | PATCH | Ensure DHCP Server is not enabled | Stop isc-dhcp-server6"
+      systemd:
+        name: isc-dhcp-server6
+        state: stopped
+        enabled: false
+      when:
+         - isc-dhcp-server6.stdout == "loaded"
   when:
       - not ubuntu1604cis_dhcp_server
-      - dhcpd_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_5
   tags:
       - level1
@@ -391,7 +326,7 @@
       - rule_2.2.5
 
 - name: "SCORED | 2.2.6 | PATCH | Ensure LDAP server is not enabled"
-  service:
+  systemd:
       name: slapd
       state: stopped
       enabled: false
@@ -408,7 +343,7 @@
       - rule_2.2.6
 
 - name: "SCORED | 2.2.7 | PATCH | Ensure NFS and RPC are not enabled"
-  service:
+  systemd:
       name: nfs
       state: stopped
       enabled: false
@@ -426,7 +361,7 @@
       - rule_2.2.7
 
 - name: "SCORED | 2.2.7 | PATCH | Ensure RPC is not enabled"
-  service:
+  systemd:
       name: rpcbind
       state: stopped
       enabled: false
@@ -444,13 +379,13 @@
       - rule_2.2.7
 
 - name: "SCORED | 2.2.8 | PATCH | Ensure DNS Server is not enabled"
-  service:
-      name: named
+  systemd:
+      name: bind9
       state: stopped
       enabled: false
   when:
-      - not ubuntu1604cis_named_server
-      - named_service_status.stdout == "loaded"
+      - not ubuntu1604cis_bind9_server
+      - bind9_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_8
   tags:
       - level1
@@ -459,7 +394,7 @@
       - rule_2.2.8
 
 - name: "SCORED | 2.2.9 | PATCH | Ensure FTP Server is not enabled"
-  service:
+  systemd:
       name: vsftpd
       state: stopped
       enabled: false
@@ -474,13 +409,13 @@
       - rule_2.2.9
 
 - name: "SCORED | 2.2.10 | PATCH | Ensure HTTP server is not enabled"
-  service:
-      name: httpd
+  systemd:
+      name: apache2
       state: stopped
       enabled: false
   when:
-      - not ubuntu1604cis_httpd_server
-      - httpd_service_status.stdout == "loaded"
+      - not ubuntu1604cis_apache2_server
+      - apache2_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_10
   tags:
       - level1
@@ -489,7 +424,7 @@
       - rule_2.2.10
 
 - name: "SCORED | 2.2.11 | PATCH | Ensure IMAP and POP3 server is not enabled"
-  service:
+  systemd:
       name: dovecot
       state: stopped
       enabled: false
@@ -504,13 +439,13 @@
       - rule_2.2.11
 
 - name: "SCORED | 2.2.12 | PATCH | Ensure Samba is not enabled"
-  service:
-      name: smb
+  systemd:
+      name: smbd
       state: stopped
       enabled: false
   when:
       - not ubuntu1604cis_smb_server
-      - smb_service_status.stdout == "loaded"
+      - smbd_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_12
   tags:
       - level1
@@ -519,7 +454,7 @@
       - rule_2.2.12
 
 - name: "SCORED | 2.2.13 | PATCH | Ensure HTTP Proxy Server is not enabled"
-  service:
+  systemd:
       name: squid
       state: stopped
       enabled: false
@@ -534,7 +469,7 @@
       - rule_2.2.13
 
 - name: "SCORED | 2.2.14 | PATCH | Ensure SNMP Server is not enabled"
-  service:
+  systemd:
       name: snmpd
       state: stopped
       enabled: false
@@ -563,13 +498,13 @@
       - patch
       - rule_2.2.15
 
-- name: "SCORED | 2.2.16 | PATCH | Ensure NIS Server is not enabled"
-  service:
-      name: ypserv
+- name: "SCORED | 2.2.16 | PATCH | Ensure rsync Server is not enabled"
+  systemd:
+      name: rsync
       state: stopped
       enabled: false
   when:
-      - not ubuntu1604cis_nis_server
+      - not ubuntu1604cis_rsync_server
       - ypserv_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_16
   tags:
@@ -578,13 +513,13 @@
       - patch
       - rule_2.2.16
 
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rsh"
-  service:
-      name: rsh.socket
+- name: "SCORED | 2.2.17 | PATCH | Ensure nis server is not enabled | rsh"
+  systemd:
+      name: nis
       state: stopped
       enabled: false
   when:
-      - not ubuntu1604cis_rsh_server
+      - not ubuntu1604cis_nis_server
       - rsh_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_17
   tags:
@@ -593,13 +528,13 @@
       - patch
       - rule_2.2.17
 
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rlogin"
-  service:
+- name: "SCORED | 2.2.17 | PATCH | Ensure nis server is not enabled | rlogin"
+  systemd:
       name: rlogin.socket
       state: stopped
       enabled: false
   when:
-      - not ubuntu1604cis_rsh_server
+      - not ubuntu1604cis_nis_server
       - rlogin_service_status.stdout == "loaded"
       - ubuntu1604cis_rule_2_2_17
   tags:
@@ -608,90 +543,12 @@
       - patch
       - rule_2.2.17
 
-- name: "SCORED | 2.2.17 | PATCH | Ensure rsh server is not enabled | rexec"
-  service:
-      name: rexec.socket
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1604cis_rsh_server
-      - rexec_service_status.stdout == "loaded"
-      - ubuntu1604cis_rule_2_2_17
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.17
-
-- name: "SCORED | 2.2.18 | PATCH | Ensure telnet server is not enabled"
-  service:
-      name: telnet
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1604cis_telnet_server
-      - telnet_service_status.stdout == "loaded"
-      - ubuntu1604cis_rule_2_2_18
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.18
-
-- name: "SCORED | 2.2.19 | PATCH | Ensure tftp server is not enabled"
-  service:
-      name: tftp
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1604cis_tftp_server
-      - tftp_service_status.stdout == "loaded"
-      - ubuntu1604cis_rule_2_2_19
-  tags:
-      - level1
-      - scored
-      - scored
-      - insecure_services
-      - tftp
-      - patch
-      - rule_2.2.19
-
-- name: "SCORED | 2.2.20 | PATCH | Ensure rsync service is not enabled "
-  service:
-      name: rsyncd
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1604cis_rsyncd_server
-      - rsyncd_service_status.stdout == "loaded"
-      - ubuntu1604cis_rule_2_2_20
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.20
-
-- name: "SCORED | 2.2.21 | PATCH | Ensure talk server is not enabled"
-  service:
-      name: ntalk
-      state: stopped
-      enabled: false
-  when:
-      - not ubuntu1604cis_ntalk_server
-      - ntalk_service_status.stdout == "loaded"
-      - ubuntu1604cis_rule_2_2_21
-  tags:
-      - level1
-      - scored
-      - patch
-      - rule_2.2.21
-
 - name: "SCORED | 2.3.1 | PATCH | Ensure NIS Client is not installed"
   apt:
-      name: ypbind
+      name: nis
       state: absent
   when:
-      - not ubuntu1604cis_ypbind_required
+      - not ubuntu1604cis_nix_required
       - ubuntu1604cis_rule_2_3_1
   tags:
       - level1
@@ -701,7 +558,9 @@
 
 - name: "SCORED | 2.3.2 | PATCH | Ensure rsh client is not installed"
   apt:
-      name: rsh
+      name:
+        - rsh-client
+        - rsh-redone-client
       state: absent
   when:
       - not ubuntu1604cis_rsh_required
@@ -740,10 +599,10 @@
 
 - name: "SCORED | 2.3.5 | PATCH | Ensure LDAP client is not installed"
   apt:
-      name: openldap-clients
+      name: ldap-utils
       state: absent
   when:
-      - not ubuntu1604cis_openldap_clients_required
+      - not ubuntu1604cis_ldap_utils_required
       - ubuntu1604cis_rule_2_3_5
   tags:
       - level1


### PR DESCRIPTION
I found some areas where the tasks didn’t line up with Guide, and some unused variables.

The biggest problem was most of section 2.1 - this was trying to handle xinetd services as system services, which isn’t correct. The way to enable/disable these would be to find files with the service name, and make sure that the line disable = yes exists in each file.

I might be making this change locally, but for now, I just “unimplemented” all of them to make it clear that they won’t work as intended, since in the default case, we would delete xinetd right after these steps.